### PR TITLE
Support any label matching pattern do-not-merge/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ date. For being ready to be merged they must:
 
   * Have the `lgtm` label.
   * Have the `approved` label.
-  * Not have the `do-not-merge/hold` label.
+  * Not have any label matching `do-not-merge/*`, i.e. `do-not-merge/hold`,  `do-not-merge/work-in-progress` etc. .
   * Not have the `needs-rebase` label.
 
 * Merge queue length: number of PRs in the merge queue at a given time.

--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -3,10 +3,12 @@ package constants
 const (
 	DateFormat = "2006-01-02T15:04:05Z"
 
-	LGTMLabel        = "lgtm"
-	ApprovedLabel    = "approved"
-	HoldLabel        = "do-not-merge/hold"
-	NeedsRebaseLabel = "needs-rebase"
+	LGTMLabel           = "lgtm"
+	ApprovedLabel       = "approved"
+	HoldLabel           = "do-not-merge/hold"
+	WorkInProgressLabel = "do-not-merge/work-in-progress"
+
+	NeedsRebaseLabel    = "needs-rebase"
 
 	MergeQueueLengthName = "AverageMergeQueueLength"
 	TimeToMergeName      = "AverageTimeToMerge"
@@ -28,3 +30,19 @@ const (
 	MergeQueueLengthBadgeName     = "avg merge queue length"
 	BadgeDataFormat               = "%.2f ± std %.2f"
 )
+
+func DoNotMergeLabels() []string {
+	return []string{
+		NeedsRebaseLabel,
+		HoldLabel,
+		WorkInProgressLabel,
+		WorkInProgressLabel,
+	}
+}
+
+func RequiredForMergeLabels() []string {
+	return []string{
+		LGTMLabel,
+		ApprovedLabel,
+	}
+}

--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -3,13 +3,11 @@ package constants
 const (
 	DateFormat = "2006-01-02T15:04:05Z"
 
-	LGTMLabel              = "lgtm"
-	ApprovedLabel          = "approved"
-	HoldLabel              = "do-not-merge/hold"
-	WorkInProgressLabel    = "do-not-merge/work-in-progress"
-	DoNotMergeLabelPattern = "do-not-merge/*"
+	LGTMLabel     = "lgtm"
+	ApprovedLabel = "approved"
 
-	NeedsRebaseLabel = "needs-rebase"
+	DoNotMergeLabelPattern = "do-not-merge/*"
+	NeedsRebaseLabel       = "needs-rebase"
 
 	MergeQueueLengthName = "AverageMergeQueueLength"
 	TimeToMergeName      = "AverageTimeToMerge"
@@ -35,8 +33,6 @@ const (
 func DoNotMergeLabels() []string {
 	return []string{
 		NeedsRebaseLabel,
-		HoldLabel,
-		WorkInProgressLabel,
 		DoNotMergeLabelPattern,
 	}
 }

--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -3,12 +3,13 @@ package constants
 const (
 	DateFormat = "2006-01-02T15:04:05Z"
 
-	LGTMLabel           = "lgtm"
-	ApprovedLabel       = "approved"
-	HoldLabel           = "do-not-merge/hold"
-	WorkInProgressLabel = "do-not-merge/work-in-progress"
+	LGTMLabel              = "lgtm"
+	ApprovedLabel          = "approved"
+	HoldLabel              = "do-not-merge/hold"
+	WorkInProgressLabel    = "do-not-merge/work-in-progress"
+	DoNotMergeLabelPattern = "do-not-merge/*"
 
-	NeedsRebaseLabel    = "needs-rebase"
+	NeedsRebaseLabel = "needs-rebase"
 
 	MergeQueueLengthName = "AverageMergeQueueLength"
 	TimeToMergeName      = "AverageTimeToMerge"
@@ -36,7 +37,7 @@ func DoNotMergeLabels() []string {
 		NeedsRebaseLabel,
 		HoldLabel,
 		WorkInProgressLabel,
-		WorkInProgressLabel,
+		DoNotMergeLabelPattern,
 	}
 }
 

--- a/pkg/mergequeue/main.go
+++ b/pkg/mergequeue/main.go
@@ -78,8 +78,29 @@ func (mq *Handler) TimesToMerge(startDate, endDate time.Time) (map[int]time.Dura
 // DatePREntered returns when a PR entered the merge queue before a
 // given date, zero value date if it was not in the merge queue by that date.
 func DatePREntered(pr *types.PullRequestFragment, date time.Time) time.Time {
-	labelsAdded := make(map[string]time.Time)
-	labelsRemoved := make(map[string]time.Time)
+	labelsAdded, labelsRemoved := createMapsFromEvents(pr, date)
+
+	if !hasAllRequiredForMergeLabels(labelsAdded, labelsRemoved) {
+		return zeroDate
+	}
+
+	if hasAnyDoNotMergeLabel(labelsAdded, labelsRemoved) {
+		return zeroDate
+	}
+
+	doNotMergeLabelRemoval := latestDoNotMergeLabelRemoval(labelsRemoved)
+	requiredForMergeLabelAddition := latestRequiredForMergeLabelAddition(labelsAdded)
+
+	if doNotMergeLabelRemoval.After(requiredForMergeLabelAddition) {
+		return doNotMergeLabelRemoval
+	}
+	return requiredForMergeLabelAddition
+}
+
+func createMapsFromEvents(pr *types.PullRequestFragment, date time.Time) (labelsAdded map[string]time.Time, labelsRemoved map[string]time.Time) {
+	labelsAdded = make(map[string]time.Time)
+	labelsRemoved = make(map[string]time.Time)
+
 	for _, timelineItem := range pr.TimelineItems.Nodes {
 		if isLabeledEvent(timelineItem, date) {
 
@@ -93,27 +114,7 @@ func DatePREntered(pr *types.PullRequestFragment, date time.Time) time.Time {
 
 		}
 	}
-
-	if !isPRInMergeQueue(labelsAdded, date) {
-		return zeroDate
-	}
-
-	if labelsRemoved[constants.HoldLabel].After(labelsAdded[constants.LGTMLabel]) &&
-		labelsRemoved[constants.HoldLabel].After(labelsAdded[constants.ApprovedLabel]) {
-
-		return labelsRemoved[constants.HoldLabel]
-	}
-	if labelsRemoved[constants.NeedsRebaseLabel].After(labelsAdded[constants.LGTMLabel]) &&
-		labelsRemoved[constants.NeedsRebaseLabel].After(labelsAdded[constants.ApprovedLabel]) {
-
-		return labelsRemoved[constants.NeedsRebaseLabel]
-	}
-
-	if labelsAdded[constants.ApprovedLabel].After(labelsAdded[constants.LGTMLabel]) {
-
-		return labelsAdded[constants.ApprovedLabel]
-	}
-	return labelsAdded[constants.LGTMLabel]
+	return
 }
 
 func isLabeledEvent(timelineItem types.TimelineItem, date time.Time) bool {
@@ -128,11 +129,40 @@ func isUnlabeledEvent(timelineItem types.TimelineItem, date time.Time) bool {
 		date.After(timelineItem.UnlabeledEventFragment.CreatedAt)
 }
 
-func isPRInMergeQueue(labelsAdded map[string]time.Time, date time.Time) bool {
-	return labelsAdded[constants.LGTMLabel].After(labelsAdded[constants.HoldLabel]) &&
-		labelsAdded[constants.LGTMLabel].After(labelsAdded[constants.NeedsRebaseLabel]) &&
-		labelsAdded[constants.LGTMLabel].Before(date) &&
-		labelsAdded[constants.ApprovedLabel].After(labelsAdded[constants.HoldLabel]) &&
-		labelsAdded[constants.ApprovedLabel].After(labelsAdded[constants.NeedsRebaseLabel]) &&
-		labelsAdded[constants.ApprovedLabel].Before(date)
+func hasAnyDoNotMergeLabel(labelsAdded map[string]time.Time, labelsRemoved map[string]time.Time) bool {
+	for _, doNotMergeLabel := range constants.DoNotMergeLabels() {
+		if labelsAdded[doNotMergeLabel] != zeroDate && !labelsRemoved[doNotMergeLabel].After(labelsAdded[doNotMergeLabel]) {
+			return true
+		}
+	}
+	return false
+}
+
+func latestDoNotMergeLabelRemoval(labelsRemoved map[string]time.Time) time.Time {
+	result := zeroDate
+	for _, doNotMergeLabel := range constants.DoNotMergeLabels() {
+		if labelsRemoved[doNotMergeLabel] != zeroDate && labelsRemoved[doNotMergeLabel].After(result) {
+			result = labelsRemoved[doNotMergeLabel]
+		}
+	}
+	return result
+}
+
+func hasAllRequiredForMergeLabels(labelsAdded map[string]time.Time, labelsRemoved map[string]time.Time) bool {
+	for _, doNotMergeLabel := range constants.RequiredForMergeLabels() {
+		if labelsAdded[doNotMergeLabel] == zeroDate || labelsRemoved[doNotMergeLabel] != zeroDate {
+			return false
+		}
+	}
+	return true
+}
+
+func latestRequiredForMergeLabelAddition(labelsAdded map[string]time.Time) time.Time {
+	result := zeroDate
+	for _, doNotMergeLabel := range constants.RequiredForMergeLabels() {
+		if labelsAdded[doNotMergeLabel] != zeroDate && labelsAdded[doNotMergeLabel].After(result) {
+			result = labelsAdded[doNotMergeLabel]
+		}
+	}
+	return result
 }

--- a/pkg/mergequeue/main.go
+++ b/pkg/mergequeue/main.go
@@ -181,8 +181,8 @@ func firstMapEntryWithKeyMatchingPatternAndNonZeroDate(labelsToTimes map[string]
 }
 
 func hasAllLabelsRequiredForMerge(labelsAdded map[string]time.Time, labelsRemoved map[string]time.Time) bool {
-	for _, doNotMergeLabel := range constants.RequiredForMergeLabels() {
-		if labelsAdded[doNotMergeLabel] == zeroDate || labelsRemoved[doNotMergeLabel] != zeroDate {
+	for _, requiredForMergeLabel := range constants.RequiredForMergeLabels() {
+		if labelsAdded[requiredForMergeLabel] == zeroDate || labelsRemoved[requiredForMergeLabel] != zeroDate {
 			return false
 		}
 	}

--- a/pkg/mergequeue/mergequeue_test.go
+++ b/pkg/mergequeue/mergequeue_test.go
@@ -161,6 +161,47 @@ var _ = Describe("DatePREntered", func() {
 			},
 			queryDate,
 			queryDate.AddDate(0, 0, -4)),
+		table.Entry("PR in merge queue: work-in-progress and removed work-in-progress",
+			&types.PullRequestFragment{
+				TimelineItems: types.TimelineItems{
+					Nodes: []types.TimelineItem{
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -7),
+								AddedLabel: types.Label{
+									Name: constants.ApprovedLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -6),
+								AddedLabel: types.Label{
+									Name: constants.WorkInProgressLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -5),
+								AddedLabel: types.Label{
+									Name: constants.LGTMLabel,
+								},
+							},
+						},
+						{
+							UnlabeledEventFragment: types.UnlabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -4),
+								RemovedLabel: types.Label{
+									Name: constants.WorkInProgressLabel,
+								},
+							},
+						},
+					},
+				},
+			},
+			queryDate,
+			queryDate.AddDate(0, 0, -4)),
 		table.Entry("PR in merge queue: needs-rebase and rebase",
 			&types.PullRequestFragment{
 				TimelineItems: types.TimelineItems{
@@ -227,6 +268,39 @@ var _ = Describe("DatePREntered", func() {
 								CreatedAt: queryDate.AddDate(0, 0, 1),
 								AddedLabel: types.Label{
 									Name: constants.HoldLabel,
+								},
+							},
+						},
+					},
+				},
+			},
+			queryDate,
+			queryDate.AddDate(0, 0, -1)),
+		table.Entry("PR in merge queue: work-in-progress after queryDate",
+			&types.PullRequestFragment{
+				TimelineItems: types.TimelineItems{
+					Nodes: []types.TimelineItem{
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -2),
+								AddedLabel: types.Label{
+									Name: constants.ApprovedLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -1),
+								AddedLabel: types.Label{
+									Name: constants.LGTMLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, 1),
+								AddedLabel: types.Label{
+									Name: constants.WorkInProgressLabel,
 								},
 							},
 						},
@@ -473,6 +547,72 @@ var _ = Describe("DatePREntered", func() {
 			},
 			queryDate,
 			zeroDate),
+		table.Entry("PR not in merge queue: with work-in-progress label",
+			&types.PullRequestFragment{
+				TimelineItems: types.TimelineItems{
+					Nodes: []types.TimelineItem{
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -3),
+								AddedLabel: types.Label{
+									Name: constants.ApprovedLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -2),
+								AddedLabel: types.Label{
+									Name: constants.LGTMLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -1),
+								AddedLabel: types.Label{
+									Name: constants.WorkInProgressLabel,
+								},
+							},
+						},
+					},
+				},
+			},
+			queryDate,
+			zeroDate),
+		table.PEntry("PR not in merge queue: with any do-not-merge prefixed label",
+			&types.PullRequestFragment{
+				TimelineItems: types.TimelineItems{
+					Nodes: []types.TimelineItem{
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -3),
+								AddedLabel: types.Label{
+									Name: constants.ApprovedLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -2),
+								AddedLabel: types.Label{
+									Name: constants.LGTMLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -1),
+								AddedLabel: types.Label{
+									Name: "do-not-merge/for-whatever-reason",
+								},
+							},
+						},
+					},
+				},
+			},
+			queryDate,
+			zeroDate),
 		table.Entry("PR not in merge queue: was previously in and lost lgtm label",
 			&types.PullRequestFragment{
 				TimelineItems: types.TimelineItems{
@@ -614,6 +754,39 @@ var _ = Describe("DatePREntered", func() {
 								CreatedAt: queryDate.AddDate(0, 0, -1),
 								AddedLabel: types.Label{
 									Name: constants.HoldLabel,
+								},
+							},
+						},
+					},
+				},
+			},
+			queryDate,
+			zeroDate),
+		table.Entry("PR not in merge queue: lgtm, approve and work-in-progress at the same time",
+			&types.PullRequestFragment{
+				TimelineItems: types.TimelineItems{
+					Nodes: []types.TimelineItem{
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -1),
+								AddedLabel: types.Label{
+									Name: constants.LGTMLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -1),
+								AddedLabel: types.Label{
+									Name: constants.ApprovedLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -1),
+								AddedLabel: types.Label{
+									Name: constants.WorkInProgressLabel,
 								},
 							},
 						},

--- a/pkg/mergequeue/mergequeue_test.go
+++ b/pkg/mergequeue/mergequeue_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/fgimenez/ci-health/pkg/types"
 )
 
+const (
+	HoldLabel              = "do-not-merge/hold"
+	WorkInProgressLabel    = "do-not-merge/work-in-progress"
+)
+
 func TestMergeQueue(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "mergequeue Suite")
@@ -136,7 +141,7 @@ var _ = Describe("DatePREntered", func() {
 							LabeledEventFragment: types.LabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, -6),
 								AddedLabel: types.Label{
-									Name: constants.HoldLabel,
+									Name: HoldLabel,
 								},
 							},
 						},
@@ -152,7 +157,7 @@ var _ = Describe("DatePREntered", func() {
 							UnlabeledEventFragment: types.UnlabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, -4),
 								RemovedLabel: types.Label{
-									Name: constants.HoldLabel,
+									Name: HoldLabel,
 								},
 							},
 						},
@@ -177,7 +182,7 @@ var _ = Describe("DatePREntered", func() {
 							LabeledEventFragment: types.LabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, -6),
 								AddedLabel: types.Label{
-									Name: constants.WorkInProgressLabel,
+									Name: WorkInProgressLabel,
 								},
 							},
 						},
@@ -193,7 +198,7 @@ var _ = Describe("DatePREntered", func() {
 							UnlabeledEventFragment: types.UnlabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, -4),
 								RemovedLabel: types.Label{
-									Name: constants.WorkInProgressLabel,
+									Name: WorkInProgressLabel,
 								},
 							},
 						},
@@ -308,7 +313,7 @@ var _ = Describe("DatePREntered", func() {
 							LabeledEventFragment: types.LabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, 1),
 								AddedLabel: types.Label{
-									Name: constants.HoldLabel,
+									Name: HoldLabel,
 								},
 							},
 						},
@@ -341,7 +346,7 @@ var _ = Describe("DatePREntered", func() {
 							LabeledEventFragment: types.LabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, 1),
 								AddedLabel: types.Label{
-									Name: constants.WorkInProgressLabel,
+									Name: WorkInProgressLabel,
 								},
 							},
 						},
@@ -579,7 +584,7 @@ var _ = Describe("DatePREntered", func() {
 							LabeledEventFragment: types.LabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, -1),
 								AddedLabel: types.Label{
-									Name: constants.HoldLabel,
+									Name: HoldLabel,
 								},
 							},
 						},
@@ -612,7 +617,7 @@ var _ = Describe("DatePREntered", func() {
 							LabeledEventFragment: types.LabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, -1),
 								AddedLabel: types.Label{
-									Name: constants.WorkInProgressLabel,
+									Name: WorkInProgressLabel,
 								},
 							},
 						},
@@ -794,7 +799,7 @@ var _ = Describe("DatePREntered", func() {
 							LabeledEventFragment: types.LabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, -1),
 								AddedLabel: types.Label{
-									Name: constants.HoldLabel,
+									Name: HoldLabel,
 								},
 							},
 						},
@@ -827,7 +832,7 @@ var _ = Describe("DatePREntered", func() {
 							LabeledEventFragment: types.LabeledEventFragment{
 								CreatedAt: queryDate.AddDate(0, 0, -1),
 								AddedLabel: types.Label{
-									Name: constants.WorkInProgressLabel,
+									Name: WorkInProgressLabel,
 								},
 							},
 						},

--- a/pkg/mergequeue/mergequeue_test.go
+++ b/pkg/mergequeue/mergequeue_test.go
@@ -202,6 +202,47 @@ var _ = Describe("DatePREntered", func() {
 			},
 			queryDate,
 			queryDate.AddDate(0, 0, -4)),
+		table.Entry("PR in merge queue: any do-not-merge prefixed label and removed any do-not-merge prefixed label",
+			&types.PullRequestFragment{
+				TimelineItems: types.TimelineItems{
+					Nodes: []types.TimelineItem{
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -7),
+								AddedLabel: types.Label{
+									Name: constants.ApprovedLabel,
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -6),
+								AddedLabel: types.Label{
+									Name: "do-not-merge/for-whatever-reason",
+								},
+							},
+						},
+						{
+							LabeledEventFragment: types.LabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -5),
+								AddedLabel: types.Label{
+									Name: constants.LGTMLabel,
+								},
+							},
+						},
+						{
+							UnlabeledEventFragment: types.UnlabeledEventFragment{
+								CreatedAt: queryDate.AddDate(0, 0, -4),
+								RemovedLabel: types.Label{
+									Name: "do-not-merge/for-whatever-reason",
+								},
+							},
+						},
+					},
+				},
+			},
+			queryDate,
+			queryDate.AddDate(0, 0, -4)),
 		table.Entry("PR in merge queue: needs-rebase and rebase",
 			&types.PullRequestFragment{
 				TimelineItems: types.TimelineItems{
@@ -580,7 +621,7 @@ var _ = Describe("DatePREntered", func() {
 			},
 			queryDate,
 			zeroDate),
-		table.PEntry("PR not in merge queue: with any do-not-merge prefixed label",
+		table.Entry("PR not in merge queue: with any do-not-merge prefixed label",
 			&types.PullRequestFragment{
 				TimelineItems: types.TimelineItems{
 					Nodes: []types.TimelineItem{


### PR DESCRIPTION
Adds support for labels matching patterns containing stars, use case is matching of any label starting with `work-in-progress/`